### PR TITLE
#29 Upgrade to newer folder layout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
                                 <unzip src="${project.build.directory}/${archiveFile}" dest="${project.build.directory}" />
                                 <echo message="moving resources" />
                                 <move todir="${destDir}">
-                                    <fileset dir="${project.build.directory}/${archiveName}" />
+                                    <fileset dir="${project.build.directory}/${archiveName}/web-fonts-with-css" />
                                 </move>
                             </target>
                         </configuration>
@@ -131,15 +131,15 @@
                 <configuration>
                     <includes>
                         <include>
-                            ${project.build.directory}/classes/META-INF/resources/webjars/font-awesome/${project.version}/*/css/*.css
+                            ${project.build.directory}/classes/META-INF/resources/webjars/font-awesome/${project.version}/css/*.css
                         </include>
                     </includes>
                     <inputFilePattern>(.*).css</inputFilePattern>
                     <outputFilePattern>$1-jsf.css</outputFilePattern>
                     <replacements>
                         <replacement>
-                            <token>url\('\.\.\/fonts\/([^?]*)\?([^']*)'</token>
-                            <value>url("#{resource['webjars:font-awesome/${version.unsnapshot}/fonts/$1']}&amp;$2"</value>
+                            <token>url\(["]*\.\.\/webfonts\/([^"\?#]*)[#\?]*([^"]*)["]*\)</token>
+                            <value>url("#{resource['webjars:font-awesome/${version.unsnapshot}/webfonts/$1']}&amp;#$2")</value>
                         </replacement>
                     </replacements>
                     <regex>true</regex>


### PR DESCRIPTION
This PR should provide a fix for the new folder layout of the Font-Awesome distribution. 

I decided to provide within the webjar only a fraction of the original distribution. The new distribution comes with various artefacts: various svg formats, nodejs styles, a javascript lib and finally the web fonts. Together they have a combined weight of (unzipped) 29 MB. I believe the usual webjar use-case does only cover the `web-fonts-with-css` folder. If my assumption is wrong, please let me know and I re-add the rest of the distribution. 
```
├── advanced-options
│   ├── metadata
│   ├── raw-svg
│   │   ├── brands
│   │   ├── regular
│   │   └── solid
│   ├── svg-sprites
│   └── use-with-node-js
│       ├── fontawesome
│       ├── fontawesome-common-types
│       ├── fontawesome-free-brands
│       ├── fontawesome-free-regular
│       ├── fontawesome-free-solid
│       └── fontawesome-free-webfonts
│           ├── css
│           ├── less
│           ├── scss
│           └── webfonts
├── svg-with-js
│   ├── css
│   └── js
├── use-on-desktop
└── web-fonts-with-css
    ├── css
    ├── less
    ├── scss
    └── webfonts
```
