### PR TITLE
Re-add entire font-awesome distribution 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
                                 <unzip src="${project.build.directory}/${archiveFile}" dest="${project.build.directory}" />
                                 <echo message="moving resources" />
                                 <move todir="${destDir}">
-                                    <fileset dir="${project.build.directory}/${archiveName}/web-fonts-with-css" />
+                                    <fileset dir="${project.build.directory}/${archiveName}/" />
                                 </move>
                             </target>
                         </configuration>
@@ -131,7 +131,7 @@
                 <configuration>
                     <includes>
                         <include>
-                            ${project.build.directory}/classes/META-INF/resources/webjars/font-awesome/${project.version}/css/*.css
+                            ${project.build.directory}/classes/META-INF/resources/webjars/font-awesome/${project.version}/*/css/*.css
                         </include>
                     </includes>
                     <inputFilePattern>(.*).css</inputFilePattern>
@@ -139,7 +139,7 @@
                     <replacements>
                         <replacement>
                             <token>url\(["]*\.\.\/webfonts\/([^"\?#]*)[#\?]*([^"]*)["]*\)</token>
-                            <value>url("#{resource['webjars:font-awesome/${version.unrevise}/webfonts/$1']}&amp;#$2")</value>
+                            <value>url("#{resource['webjars:font-awesome/${version}/web-fonts-with-css/webfonts/$1']}&amp;#$2")</value>
                         </replacement>
                     </replacements>
                     <regex>true</regex>


### PR DESCRIPTION
Here is my proposal for #32 

As requested is the entire font-awesome distribution back in the package. As @ceoche also mentioned are the version paths within the `-jsf` css files wrong. This was introduced with the bugfix release schema together with the unsnapshot version which uses only the part before the [last minus sign](https://github.com/jamesward/unsnapshot-maven-plugin/blob/master/src/main/java/com/jamesward/unsnapshot/UnsnapshotMojo.java#L26). Now it uses `${version}` which should result in consistent version naming. 
