### PR TITLE
Fix #47: Fixed regex for JSF file replacement.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,8 +138,8 @@
                     <outputFilePattern>$1-jsf.css</outputFilePattern>
                     <replacements>
                         <replacement>
-                            <token>url\(["]*\.\.\/webfonts\/([^"\?#]*)[#\?]*([^"]*)["]*\)</token>
-                            <value>url("#{resource['webjars:font-awesome/${project.version}/webfonts/$1']}&amp;#$2")</value>
+                            <token>url\((["']?)\.\.\/webfonts\/([^"?#)]*)(?:\??#([^")]*))?\1\)</token>
+                            <value>url("#{resource['webjars:font-awesome/${project.version}/webfonts/$2']}&amp;#$3")</value>
                         </replacement>
                     </replacements>
                     <regex>true</regex>


### PR DESCRIPTION
OK fixes the regex to work for all scenarios.  Fontawesome 5.8.2 was released can you merge this PR and release for 5.8.2?